### PR TITLE
Remove recompile_invalidations

### DIFF
--- a/src/NonlinearSolveBase.jl
+++ b/src/NonlinearSolveBase.jl
@@ -1,15 +1,11 @@
 module NonlinearSolveBase
 
-import PrecompileTools: @recompile_invalidations
-
-@recompile_invalidations begin
-    import ArrayInterface, SciMLBase, StaticArraysCore
-    import ConcreteStructs: @concrete
-    import FastClosures: @closure
-    import LinearAlgebra: norm
-    import Markdown: @doc_str
-    import SciMLBase: ReturnCode
-end
+import ArrayInterface, SciMLBase, StaticArraysCore
+import ConcreteStructs: @concrete
+import FastClosures: @closure
+import LinearAlgebra: norm
+import Markdown: @doc_str
+import SciMLBase: ReturnCode
 
 include("common_defaults.jl")
 include("termination_conditions.jl")

--- a/src/recursivearraytools.jl
+++ b/src/recursivearraytools.jl
@@ -1,6 +1,4 @@
-@recompile_invalidations begin
-    import RecursiveArrayTools
-end
+import RecursiveArrayTools
 
 @inline function UNITLESS_ABS2(x::RecursiveArrayTools.AbstractVectorOfArray)
     return mapreduce(UNITLESS_ABS2, NonlinearSolveBase.__abs2_and_sum,


### PR DESCRIPTION
`@recompile_invalidations` should only be used in very specific scenarios, and this is not one of those scenarios. Also, there are big changes being done with https://github.com/SciML/CommonWorldInvalidations.jl. With that, we only need to `@recompile_invalidations` on a few entry points. In particular, Static.jl, Symbolics.jl, and preferably ForwardDiff.jl and StaticArrays.jl would adopt it too. But this means that in order to handle all of this effectively, in SciML we only need to apply it on Static.jl, Symbolics.jl, and SciMLBase.jl and the whole ecosystem should be fine.

In any case, this library doesn't need it. It shouldn't make a tangible difference in compile times, while it increases precompile times by a lot.